### PR TITLE
Add human-readable serialization for OIDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "base64",
  "ciborium",
  "derive_more",
+ "oid",
  "serde",
  "serde_json",
 ]
@@ -99,6 +100,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "oid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c19903c598813dba001b53beeae59bb77ad4892c5c1b9b3500ce4293a0d06c2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ derive_more = { version = "^2", features = [
     "constructor",
 ] }
 base64 = "0.22.1"
+oid = { version = "0.2.1", features = ["serde", "serde_support"] }
 
 [dev-dependencies]
 serde_json = "1.0.140"


### PR DESCRIPTION
Add ObjectIdentifier representing an untagged OID. Use oid crate to
provide string serialization and validation. OidType is changed to use
ObjectIdentifier instead of Bytes.

Note: this only provides a string representation for untagged OIDs; To
correctly serialize OidType for human-readable fromats, generate_tagged!
macro needs to be updated.

This partially addresses https://github.com/larrydewey/corim-rs/issues/6 (to fully address it, https://github.com/larrydewey/corim-rs/issues/4 needs to be implemented).

NOTE: this is implemented on top of https://github.com/larrydewey/corim-rs/pull/9