### PR TITLE
Add human-readable serialization for UUIDs 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,7 @@ dependencies = [
  "oid",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -182,3 +183,9 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ derive_more = { version = "^2", features = [
 ] }
 base64 = "0.22.1"
 oid = { version = "0.2.1", features = ["serde", "serde_support"] }
+uuid = "1.16.0"
 
 [dev-dependencies]
 serde_json = "1.0.140"


### PR DESCRIPTION
Add string conversions for UuidType to/from the standard UUID textual
representation (hex encoded in groups of 4, 2, 2, 2, and 6 bytes
separated by hyphens).

Use these when serializing to/from a human-readable format.

This partially addresses: https://github.com/larrydewey/corim-rs/issues/7 (to fully address it, https://github.com/larrydewey/corim-rs/issues/4 needs to be implemented).

NOTE: this is implemented on top of https://github.com/larrydewey/corim-rs/pull/11