### PR TITLE
Align UEID implementation with EAT spec

### DIFF
--- a/src/error/core.rs
+++ b/src/error/core.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum CoreError {
+    InvalidValue(String),
     Unknown,
 }
 
@@ -10,6 +11,7 @@ impl std::error::Error for CoreError {}
 impl std::fmt::Display for CoreError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::InvalidValue(s) => write!(f, "invalid value: \"{s}\""),
             Self::Unknown => write!(f, "unknown CoreError encountered"),
         }
     }


### PR DESCRIPTION
- Change the implementation of UEID from a fixed 33 bytes to a variable
  between 7 and 33 Bytes as defined by [ietf-rats-eat][1].
- Add human-readable serialisation as base 64 URL encoded string without
  padding.

[1]: https://datatracker.ietf.org/doc/html/draft-ietf-rats-eat-31#section-4.2.1

NOTE: this is implemented on top of https://github.com/larrydewey/corim-rs/pull/12