### PR TITLE
fix `ClassIdTypeChoice` and add human-readable serialization for tags

### DIFF
--- a/src/comid.rs
+++ b/src/comid.rs
@@ -94,7 +94,7 @@ use crate::{
     ReferenceTripleRecord, Result, Text, Tstr, Uint, Uri, UuidType,
 };
 use derive_more::{Constructor, From, TryFrom};
-use serde::{Deserialize, Serialize};
+use serde::{ser::SerializeMap, Deserialize, Serialize};
 
 /// A tag version number represented as an unsigned integer
 pub type TagVersionType = Uint;
@@ -104,6 +104,7 @@ generate_tagged!((
     TaggedConciseMidTag,
     ConciseMidTag<'a>,
     'a,
+    "comid",
     "A Concise Module Identifier (CoMID) structured tag"
 ),);
 /// A Concise Module Identifier (CoMID) tag structure tagged with CBOR tag 506

--- a/src/core.rs
+++ b/src/core.rs
@@ -48,7 +48,7 @@ use base64::{self, engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use derive_more::{AsMut, AsRef, Constructor, Deref, DerefMut, From, TryFrom};
 use serde::{
     de::{self, SeqAccess, Visitor},
-    ser::{Error as _, SerializeSeq},
+    ser::{Error as _, SerializeMap, SerializeSeq},
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
@@ -616,23 +616,23 @@ impl<'de> Deserialize<'de> for ObjectIdentifier {
 }
 
 generate_tagged!(
-    (1, IntegerTime, Int, "A representation of time in integer format using CBOR tag 1"),
-    (32, Uri, Text<'a>, 'a,  "A URI text string with CBOR tag 32"),
-    (37, TaggedUuidType, UuidType, "UUID type wrapped with CBOR tag 37"),
-    (111, OidType, ObjectIdentifier, "An Object Identifier (OID) represented as bytes using CBOR tag 111"),
-    (550, TaggedUeidType, UeidType, "UEID type wrapped with CBOR tag 550"),
-    (552, SvnType, Uint, "A Security Version Number (SVN) using CBOR tag 552"),
-    (553, MinSvnType, Uint, "A minimum Security Version Number (SVN) using CBOR tag 553"),
-    (554, PkixBase64KeyType, Tstr<'a>, 'a, "A PKIX key in base64 format using CBOR tag 554"),
-    (555, PkixBase64CertType, Tstr<'a>, 'a, "A PKIX certificate in base64 format using CBOR tag 555"),
-    (556, PkixBase64CertPathType, Tstr<'a>, 'a, "A PKIX certificate path in base64 format using CBOR tag 556"),
-    (557, ThumbprintType, Digest<'a>, 'a, "A cryptographic thumbprint using CBOR tag 557"),
-    (558, CoseKeyType, CoseKeySetOrKey<'a>, 'a, "CBOR tag 558 wrapper for COSE Key Structures"),
-    (559, CertThumprintType, Digest<'a>, 'a, "A certificate thumbprint using CBOR tag 559"),
-    (560, TaggedBytes, Bytes, "A generic byte string using CBOR tag 560"),
-    (561, CertPathThumbprintType, Digest<'a>, 'a, "A certificate path thumbprint using CBOR tag 561"),
-    (562, PkixAsn1DerCertType, TaggedBytes, "A PKIX certificate in ASN.1 DER format using CBOR tag 562"),
-    (563, TaggedMaskedRawValue, MaskedRawValue, "Represents a masked raw value with its mask"),
+    (1, IntegerTime, Int, "time", "A representation of time in integer format using CBOR tag 1"),
+    (32, Uri, Text<'a>, 'a,  "uri", "A URI text string with CBOR tag 32"),
+    (37, TaggedUuidType, UuidType, "uuid", "UUID type wrapped with CBOR tag 37"),
+    (111, OidType, ObjectIdentifier, "oid", "An Object Identifier (OID) represented as bytes using CBOR tag 111"),
+    (550, TaggedUeidType, UeidType, "ueid", "UEID type wrapped with CBOR tag 550"),
+    (552, SvnType, Uint, "svn", "A Security Version Number (SVN) using CBOR tag 552"),
+    (553, MinSvnType, Uint, "min-svn", "A minimum Security Version Number (SVN) using CBOR tag 553"),
+    (554, PkixBase64KeyType, Tstr<'a>, 'a, "pkix-base64-key", "A PKIX key in base64 format using CBOR tag 554"),
+    (555, PkixBase64CertType, Tstr<'a>, 'a, "pkix-base64-cert", "A PKIX certificate in base64 format using CBOR tag 555"),
+    (556, PkixBase64CertPathType, Tstr<'a>, 'a, "pkix-base64-cert-path", "A PKIX certificate path in base64 format using CBOR tag 556"),
+    (557, ThumbprintType, Digest<'a>, 'a, "thumbprint", "A cryptographic thumbprint using CBOR tag 557"),
+    (558, CoseKeyType, CoseKeySetOrKey<'a>, 'a, "cose-key", "CBOR tag 558 wrapper for COSE Key Structures"),
+    (559, CertThumprintType, Digest<'a>, 'a, "cert-thumbprint", "A certificate thumbprint using CBOR tag 559"),
+    (560, TaggedBytes, Bytes, "bytes", "A generic byte string using CBOR tag 560"),
+    (561, CertPathThumbprintType, Digest<'a>, 'a, "cert-path-thumbprint", "A certificate path thumbprint using CBOR tag 561"),
+    (562, PkixAsn1DerCertType, TaggedBytes, "pkix-asn1-der-cert", "A PKIX certificate in ASN.1 DER format using CBOR tag 562"),
+    (563, TaggedMaskedRawValue, MaskedRawValue, "masked-raw-value", "Represents a masked raw value with its mask"),
 );
 
 /// Represents a value that can be either text or bytes

--- a/src/corim.rs
+++ b/src/corim.rs
@@ -89,6 +89,7 @@ use crate::{
 use derive_more::{Constructor, From, TryFrom};
 use serde::{
     de::{self, Visitor},
+    ser::SerializeMap,
     Deserialize, Deserializer, Serialize, Serializer,
 };
 /// Represents a Concise Reference Integrity Manifest (CoRIM)
@@ -186,6 +187,7 @@ generate_tagged!(
         TaggedUnsignedCorimMap,
         CorimMap<'a>,
         'a,
+        "unsigned-corim",
         "A CBOR tagged, unsigned CoRIM Map."
     ),
     (
@@ -193,6 +195,7 @@ generate_tagged!(
         TaggedCOSESign1Corim,
         COSESign1Corim<'a>,
         'a,
+        "signed-corim",
         "A CBOR tagged, signed CoRIM."
     )
 );

--- a/src/coswid.rs
+++ b/src/coswid.rs
@@ -73,9 +73,9 @@ use crate::{
     VersionScheme,
 };
 use derive_more::{Constructor, From, TryFrom};
-use serde::{Deserialize, Serialize};
+use serde::{ser::SerializeMap, Deserialize, Serialize};
 
-generate_tagged!((505, TaggedConciseSwidTag, ConciseSwidTag<'a>, 'a, "Represents a CoSWID tag wrapped with CBOR tag 505"));
+generate_tagged!((505, TaggedConciseSwidTag, ConciseSwidTag<'a>, 'a, "coswid", "Represents a CoSWID tag wrapped with CBOR tag 505"));
 
 /// A Concise Software Identity (CoSWID) tag structure as defined in RFC 9393
 ///

--- a/src/cotl.rs
+++ b/src/cotl.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use derive_more::{Constructor, From};
-use serde::{Deserialize, Serialize};
+use serde::{ser::SerializeMap, Deserialize, Serialize};
 
 use crate::{generate_tagged, TagIdentityMap, ValidityMap};
 
@@ -10,6 +10,7 @@ generate_tagged!((
     TaggedConciseTlTag,
     ConciseTlTag<'a>,
     'a,
+    "cotl",
     r#"A Concise Trust List (CoTL) tag structure tagged with CBOR tag 508
 
 CoTL tags provide a mechanism to maintain lists of trusted CoMID and CoSWID tags. 

--- a/src/error/core.rs
+++ b/src/error/core.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum CoreError {
+    InvalidValue(String),
     Unknown,
 }
 
@@ -10,6 +11,7 @@ impl std::error::Error for CoreError {}
 impl std::fmt::Display for CoreError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::InvalidValue(s) => write!(f, "invalid value: \"{s}\""),
             Self::Unknown => write!(f, "unknown CoreError encountered"),
         }
     }

--- a/src/triples.rs
+++ b/src/triples.rs
@@ -99,8 +99,8 @@ use crate::{
     core::PkixBase64CertPathType, empty_map_as_none, Bytes, CertPathThumbprintType,
     CertThumprintType, ConciseSwidTagId, CoseKeyType, Digest, ExtensionMap, MinSvnType, OidType,
     OneOrMore, PkixAsn1DerCertType, PkixBase64CertType, PkixBase64KeyType, RawValueType, Result,
-    SvnType, Text, ThumbprintType, TriplesError, Tstr, UeidType, Uint, Ulabel, UuidType,
-    VersionScheme,
+    SvnType, TaggedBytes, TaggedUuidType, Text, ThumbprintType, TriplesError, Tstr, UeidType, Uint,
+    Ulabel, UuidType, VersionScheme,
 };
 use derive_more::{Constructor, From, TryFrom};
 use serde::{
@@ -317,9 +317,9 @@ pub enum ClassIdTypeChoice {
     /// Object Identifier (OID)
     Oid(OidType),
     /// UUID identifier
-    Uuid(UuidType),
+    Uuid(TaggedUuidType),
     /// Raw bytes
-    Bytes(Bytes),
+    Bytes(TaggedBytes),
 }
 
 impl ClassIdTypeChoice {
@@ -345,7 +345,7 @@ impl ClassIdTypeChoice {
     pub fn as_bytes(&self) -> &[u8] {
         match self {
             Self::Oid(oid_type) => oid_type.as_ref(),
-            Self::Uuid(uuid_type) => uuid_type.as_ref(),
+            Self::Uuid(uuid_type) => uuid_type.as_ref().as_ref(),
             Self::Bytes(bytes) => bytes.as_ref(),
         }
     }

--- a/src/triples.rs
+++ b/src/triples.rs
@@ -2101,3 +2101,60 @@ impl<'de, 'a> Deserialize<'de> for ConditionalEndorsementTripleRecord<'a> {
         })
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::core::*;
+
+    #[test]
+    fn test_class_id_json_serde() {
+        let class_id_oid = ClassIdTypeChoice::Oid(OidType::from(
+            ObjectIdentifier::try_from("1.2.3.4").unwrap(),
+        ));
+
+        let actual = serde_json::to_string(&class_id_oid).unwrap();
+
+        let expected = r#"{"type":"oid","value":"1.2.3.4"}"#;
+
+        assert_eq!(actual, expected);
+
+        let other: ClassIdTypeChoice = serde_json::from_str(expected).unwrap();
+
+        assert_eq!(class_id_oid, other);
+
+        let class_id_bytes =
+            ClassIdTypeChoice::Bytes(Bytes::from(&[0xde, 0xad, 0xbe, 0xef][..]).into());
+
+        let expected = r#"{"type":"bytes","value":"3q2-7w"}"#;
+
+        let actual = serde_json::to_string(&class_id_bytes).unwrap();
+
+        assert_eq!(actual, expected);
+
+        let other: ClassIdTypeChoice = serde_json::from_str(expected).unwrap();
+
+        assert_eq!(class_id_bytes, other);
+
+        let class_id_uuid = ClassIdTypeChoice::Uuid(TaggedUuidType::from(
+            UuidType::try_from("550e8400-e29b-41d4-a716-446655440000").unwrap(),
+        ));
+
+        let actual = serde_json::to_string(&class_id_uuid).unwrap();
+
+        let expected = r#"{"type":"uuid","value":"550e8400-e29b-41d4-a716-446655440000"}"#;
+
+        assert_eq!(actual, expected);
+
+        let bad_tag = r#"{"type":"foo","value":"3q2-7w"}"#;
+
+        let err = serde_json::from_str::<ClassIdTypeChoice>(bad_tag)
+            .err()
+            .unwrap();
+
+        assert_eq!(
+            err.to_string(),
+            "data did not match any variant of untagged enum ClassIdTypeChoice".to_string()
+        );
+    }
+}


### PR DESCRIPTION
- Ensure all variants of `ClassIdTypChoice` use tagged types (as per the spec).
- Serialize tagged types into human-readable formats as maps with "type" entry identifying the type (i.e  the tag), and "value" entry containing the serialization of the inner type.

This addresses https://github.com/larrydewey/corim-rs/issues/4.

NOTE: this is implemented on top of https://github.com/larrydewey/corim-rs/pull/13