### PR TITLE
Digests fix algorithm + human-readable serialization

### DIFF
--- a/src/corim.rs
+++ b/src/corim.rs
@@ -425,7 +425,7 @@ pub struct CorimLocatorMap<'a> {
     /// Optional cryptographic thumbprint for verification
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "1")]
-    pub thumbprint: Option<Digest<'a>>,
+    pub thumbprint: Option<Digest>,
 }
 
 /// Profile identifier that can be either a URI or OID

--- a/src/triples.rs
+++ b/src/triples.rs
@@ -573,11 +573,11 @@ pub enum CryptoKeyTypeChoice<'a> {
     /// COSE key structure
     CoseKey(CoseKeyType<'a>),
     /// Generic cryptographic thumbprint
-    Thumbprint(ThumbprintType<'a>),
+    Thumbprint(ThumbprintType),
     /// Certificate thumbprint
-    CertThumbprint(CertThumprintType<'a>),
+    CertThumbprint(CertThumprintType),
     /// Certificate path thumbprint
-    CertPathThumbprint(CertPathThumbprintType<'a>),
+    CertPathThumbprint(CertPathThumbprintType),
     /// ASN.1 DER encoded PKIX certificate
     PkixAsn1DerCert(PkixAsn1DerCertType),
     /// Raw bytes
@@ -836,7 +836,7 @@ pub struct MeasurementValuesMap<'a> {
     /// Optional cryptographic digest
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "2")]
-    pub digest: Option<DigestsType<'a>>,
+    pub digest: Option<DigestsType>,
     /// Optional status flags
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "3")]
@@ -890,7 +890,7 @@ pub struct MeasurementValuesMapBuilder<'a> {
     /// Optional security version number
     pub svn: Option<SvnTypeChoice>,
     /// Optional cryptographic digest
-    pub digest: Option<DigestsType<'a>>,
+    pub digest: Option<DigestsType>,
     /// Optional status flags
     pub flags: Option<FlagsMap<'a>>,
     /// Optional raw measurement value
@@ -924,7 +924,7 @@ impl<'a> MeasurementValuesMapBuilder<'a> {
         self.svn = Some(value);
         self
     }
-    pub fn digest(mut self, value: DigestsType<'a>) -> Self {
+    pub fn digest(mut self, value: DigestsType) -> Self {
         self.digest = Some(value);
         self
     }
@@ -1060,7 +1060,7 @@ impl SvnTypeChoice {
 }
 
 /// Collection of one or more cryptographic digests
-pub type DigestsType<'a> = Vec<Digest<'a>>;
+pub type DigestsType = Vec<Digest>;
 
 /// Status flags indicating various security and configuration states
 #[derive(Default, Debug, Serialize, Deserialize, From, PartialEq, Eq, PartialOrd, Ord, Clone)]


### PR DESCRIPTION
Up to this point, AlgLabel was used for alg field inside Digest. This
can be either an arbitrary string, or one of CoseAlgorithm (IANA COSE
registry) IDs. [CoRIM spec][1] specifies that the Digest algorithm must
be interpreted according to the [IANA Named Information Hash Algorithm
Registry][2].

This replaced AlgLabel with HashAlogrithm that ensures that
- only valid names from the Hash Alg. Registry can be specified (rather
  than arbitrary strings).
- integer IDs are interpreted according to the Hash Alg. Registry (it
  contains a much smaller set of algorithms than the COSE registry, and
  for algorithms that appear in both, the numerical IDs differ).
- When serializing to CBOR, the integer ID is preferred where possible,
  as is recommended by the CoRIM spec. When serializing to
  human-readable format, the readable string name is used.

This also adds human-readable serialization for Digest. It is encoded
according to [RFC 6920][3], with the algorithm string name and the
base 64 encoding of the hash delimited by a ";".

[1]: https://www.ietf.org/archive/id/draft-ietf-rats-corim-07.html#name-digest
[2]: https://www.iana.org/assignments/named-information/named-information.xhtml
[3]: https://www.rfc-editor.org/rfc/rfc6920.html#section-3

NOTE: this is implemented on top of https://github.com/larrydewey/corim-rs/pull/14