### PR TITLE
Replace ToString with Display for Bytes

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -40,6 +40,7 @@
 use std::{
     borrow::Cow,
     collections::BTreeMap,
+    fmt::Display,
     ops::{Deref, DerefMut, Index, IndexMut},
 };
 
@@ -108,9 +109,9 @@ impl TryFrom<String> for Bytes {
     }
 }
 
-impl ToString for Bytes {
-    fn to_string(&self) -> String {
-        URL_SAFE_NO_PAD.encode::<&[u8]>(&self.bytes)
+impl Display for Bytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(URL_SAFE_NO_PAD.encode(&self.bytes).as_str())
     }
 }
 


### PR DESCRIPTION
Implement Display instead of ToString for Bytes. There already exists a standard ToString implementationfor Display, but the reverse is not true. Implementing Display also allows using Bytes inside format!() without an explicit to_string() call.