### PR TITLE
Human-readable serialization for ClassMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,5 @@ derive_more = { version = "^2", features = [
 base64 = "0.22.1"
 oid = { version = "0.2.1", features = ["serde", "serde_support"] }
 uuid = "1.16.0"
+serde_json = {version = "1.0.140", features = ["raw_value"]}
 
-[dev-dependencies]
-serde_json = "1.0.140"

--- a/src/core.rs
+++ b/src/core.rs
@@ -52,7 +52,9 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
-use crate::{empty::Empty, empty_map_as_none, error::CoreError, generate_tagged, FixedBytes, Integer};
+use crate::{
+    empty::Empty, empty_map_as_none, error::CoreError, generate_tagged, FixedBytes, Integer,
+};
 
 /// Text represents a UTF-8 string value
 pub type Text<'a> = Cow<'a, str>;

--- a/src/corim.rs
+++ b/src/corim.rs
@@ -769,6 +769,7 @@ pub type EntityNameTypeChoice<'a> = Text<'a>;
 pub type CoseMap<'a> = ExtensionMap<'a>;
 
 #[cfg(test)]
+#[rustfmt::skip::macros(vec)]
 mod tests {
 
     use crate::comid::{
@@ -796,22 +797,143 @@ mod tests {
     /// ```
     ///
     fn test_cose_sign1_corim_serialize_deserialize() {
-        let expected: [u8; 276] = [
-            132, 88, 65, 191, 97, 49, 38, 97, 51, 116, 97, 112, 112, 108, 105, 99, 97, 116, 105,
-            111, 110, 47, 114, 105, 109, 43, 99, 98, 111, 114, 97, 52, 71, 107, 101, 121, 45, 48,
-            48, 49, 97, 56, 161, 97, 48, 191, 97, 48, 110, 69, 120, 97, 109, 112, 108, 101, 32, 83,
-            105, 103, 110, 101, 114, 97, 49, 246, 255, 255, 160, 88, 200, 217, 1, 245, 191, 97, 48,
-            105, 99, 111, 114, 105, 109, 45, 48, 48, 49, 97, 49, 130, 217, 1, 249, 191, 97, 48,
-            104, 115, 119, 105, 100, 45, 49, 50, 51, 98, 49, 50, 0, 97, 49, 112, 69, 120, 97, 109,
-            112, 108, 101, 32, 83, 111, 102, 116, 119, 97, 114, 101, 97, 50, 191, 98, 51, 49, 110,
-            69, 120, 97, 109, 112, 108, 101, 32, 69, 110, 116, 105, 116, 121, 98, 51, 51, 1, 255,
-            255, 217, 1, 250, 191, 97, 48, 101, 101, 110, 95, 85, 83, 97, 49, 161, 97, 48, 107, 83,
-            111, 109, 101, 32, 84, 97, 103, 32, 73, 68, 97, 50, 129, 191, 98, 51, 49, 111, 83, 111,
-            109, 101, 32, 67, 111, 77, 73, 68, 32, 78, 97, 109, 101, 98, 51, 51, 129, 246, 255, 97,
-            52, 191, 97, 48, 129, 130, 161, 97, 48, 161, 97, 49, 107, 83, 111, 109, 101, 32, 86,
-            101, 110, 100, 111, 114, 129, 162, 97, 48, 104, 83, 111, 109, 101, 32, 75, 101, 121,
-            97, 49, 191, 98, 49, 49, 105, 83, 111, 109, 101, 32, 78, 97, 109, 101, 255, 255, 255,
-            255, 217, 2, 48, 65, 0,
+        let expected = vec![
+            0x84, // array(4)
+              0x58, 0x41, // bstr(65) -- COSE protected header
+                0xbf, // map(indef)
+                  0x61, // key: tstr(1)
+                    0x31, // "1"
+                  0x26, // value: -7
+                  0x61, // key: tstr(1)
+                    0x33, // "3"
+                  0x74, // value: tstr(20)
+                    0x61, 0x70, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x74, // "applicat"
+                    0x69, 0x6f, 0x6e, 0x2f, 0x72, 0x69, 0x6d, 0x2b, // "ion/rim+"
+                    0x63, 0x62, 0x6f, 0x72,                         // "cbor"
+                  0x61, // key: tstr(1)
+                    0x34, // "4"
+                  0x47, // value: bstr(7)
+                    0x6b, 0x65, 0x79, 0x2d, 0x30, 0x30, 0x31,
+                  0x61, // key: tstr(1)
+                    0x38, // "8"
+                  0xa1, // value: map(1)
+                    0x61, // key: tstr(1)
+                      0x30, // "0"
+                    0xbf, // value: map(indef)
+                      0x61, // key: tstr(1)
+                        0x30, // "1"
+                      0x6e, // value: tstr(14)
+                        0x45, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x20, // "Example "
+                        0x53, 0x69, 0x67, 0x6e, 0x65, 0x72,             // "Signer"
+                      0x61, // key: tstr(1)
+                        0x31, // "1"
+                      0xf6, // value: null
+                    0xff, // break
+                0xff, // break
+              0xa0, // map(0) -- COSE unprotected header
+              0x58, 0xc8, // bstr(200) -- COSE payload
+                0xd9, 0x01, 0xf5, // tag(501) -- CoRIM
+                  0xbf, // map(indef)
+                    0x61, // key: tstr(1)
+                      0x30, // "0"
+                    0x69, // value: tstr(9)
+                      0x63, 0x6f, 0x72, 0x69, 0x6d, 0x2d, 0x30, 0x30, // "corim-00"
+                      0x31,                                           // "1"
+                    0x61, // key: tstr(1)
+                      0x31, // "1"
+                    0x82, // value: array(2)
+                      0xd9, 0x01, 0xf9, // tag(505) -- CoSWID
+                        0xbf, // map(indef)
+                          0x61, // key: tstr(1)
+                            0x30, // "0"
+                          0x68, // value: tstr(8)
+                            0x73, 0x77, 0x69, 0x64, 0x2d, 0x31, 0x32, 0x33,  // "swid-123"
+                          0x62,  // key: tstr(2)
+                            0x31, 0x32, // "12"
+                          0x00, // value: 0
+                          0x61, // key: tstr(1)
+                            0x31, // "1"
+                          0x70, // value: tstr(16)
+                            0x45, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x20, // "Example "
+                            0x53, 0x6f, 0x66, 0x74, 0x77, 0x61, 0x72, 0x65, // "Software"
+                          0x61, // key: tstr(1)
+                            0x32, // "2"
+                          0xbf, // value: map(indef)
+                            0x62, // key: tstr(2)
+                              0x33, 0x31, // "31"
+                            0x6e, // value: tstr(14)
+                              0x45, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x20, // "Example "
+                              0x45, 0x6e, 0x74, 0x69, 0x74, 0x79,             // "Entity"
+                            0x62, // key: tstr(2)
+                              0x33, 0x33, // "33"
+                            0x01, // value: 1
+                          0xff,  // break(map)
+                        0xff,  // break(map)
+                      0xd9, 0x01, 0xfa, // tag (506) -- CoMID
+                        0xbf, // map(indef)
+                          0x61, // key: tstr(1)
+                            0x30, // "0"
+                          0x65, // value: tstr(5)
+                            0x65, 0x6e, 0x5f, 0x55, 0x53, // "en_US"
+                          0x61, // key: tstr(1)
+                            0x31, // "1"
+                          0xa1, // value: map(1)
+                            0x61, // key: tstr(1)
+                              0x30, // "0"
+                            0x6b, // value: tstr(11)
+                              0x53, 0x6f, 0x6d, 0x65, 0x20, 0x54, 0x61, 0x67, // "Some Tag"
+                              0x20, 0x49, 0x44,                               // " ID"
+                          0x61, // key: tstr(1)
+                            0x32, // "2"
+                          0x81, // value: array(1)
+                            0xbf, // map(indef)
+                              0x62, // key: tstr(2)
+                                0x33, 0x31, // "31"
+                              0x6f, // value: tstr(15)
+                                0x53, 0x6f, 0x6d, 0x65, 0x20, 0x43, 0x6f, 0x4d,
+                                0x49, 0x44, 0x20, 0x4e, 0x61, 0x6d, 0x65,
+                              0x62, // key: tstr(2)
+                                0x33, 0x33, // "33"
+                              0x81, // value: array(1)
+                                0xf6, // null
+                            0xff, // break(map)
+                          0x61, // key: tstr(1)
+                            0x34, // "4"
+                          0xbf, // value: map(indef)
+                            0x61, // key: tstr(1)
+                              0x30, // "0"
+                            0x81, // value: array(1)
+                              0x82, // array(2)
+                                0xa1, //  map(1)
+                                  0x61, // key: tstr(1)
+                                    0x30, // "0"
+                                  0xbf, // value: map(indef)
+                                    0x01, // key: 1
+                                    0x6b, // value: tstr(11)
+                                      0x53, 0x6f, 0x6d, 0x65, 0x20, 0x56, 0x65, 0x6e, // "Some Ven"
+                                      0x64, 0x6f, 0x72,                               // "dor"
+                                  0xff,
+                                0x81, // array(1)
+                                  0xa2, // map(2)
+                                    0x61, // key: tstr(1)
+                                      0x30, // "0"
+                                    0x68, // value: str(8)
+                                      0x53, 0x6f, 0x6d, 0x65, 0x20, 0x4b, 0x65, 0x79, // "Some Key"
+                                    0x61, // key: tstr(1)
+                                      0x31, // "1"
+                                    0xbf, // value: map(indef)
+                                      0x62, // key: tstr(2)
+                                        0x31, 0x31, // "11"
+                                      0x69, // value: tstr(9)
+                                        0x53, 0x6f, 0x6d, 0x65, 0x20, 0x4e, 0x61, 0x6d, // "Some Nam"
+                                        0x65,                                           // "e"
+                                    0xff, // break
+                          0xff, // break
+                        0xff, // break
+                  0xff, // break
+              0xd9, 0x02, 0x30, // tag(560) -- COSE signature
+                0x41, // bstr(1)
+                  0x00
         ];
 
         let triples = TriplesMapBuilder::default()

--- a/src/corim.rs
+++ b/src/corim.rs
@@ -102,6 +102,7 @@ pub type UnsignedCorimMap<'a> = CorimMap<'a>;
 /// A type choice representing either a signed or unsigned CoRIM manifest
 #[repr(C)]
 #[derive(Debug, From, TryFrom)]
+#[allow(clippy::large_enum_variant)]
 pub enum ConciseRimTypeChoice<'a> {
     /// An unprotected CoRIM with CBOR tag 501
     TaggedUnsignedCorimMap(TaggedUnsignedCorimMap<'a>),

--- a/src/numbers.rs
+++ b/src/numbers.rs
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: MIT
 
 use std::{
-    cmp::Ordering, fmt::{Debug, Display}, hash::Hash, i128, ops::{
+    cmp::Ordering,
+    fmt::{Debug, Display},
+    hash::Hash,
+    i128,
+    ops::{
         Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Deref,
         DerefMut, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Shl, ShlAssign, Shr,
         ShrAssign, Sub, SubAssign,
-    }, str::FromStr
+    },
+    str::FromStr,
 };
 
 use serde::Serialize;
@@ -22,7 +27,7 @@ macro_rules! all_integers {
 /// the [`Inner`] type of [`EncodedInteger`].
 mod private {
     /// A sealed trait that prevents external implementations of the `IntegerType` trait.
-    /// 
+    ///
     /// This trait is part of the sealed traits pattern, ensuring that only types
     /// within this crate can implement the public `IntegerType` trait.
     pub trait Sealed {}
@@ -186,18 +191,17 @@ pub trait WrappedInteger {
 #[derive(Default, PartialEq, Eq, Clone, Copy, Ord, PartialOrd)]
 pub struct Integer(pub i128);
 
-
 impl Integer {
     // Add these constants to the impl block
     /// Constant representing zero
     pub const ZERO: Self = Integer(0);
-    
+
     /// Constant representing one
     pub const ONE: Self = Integer(1);
 
     /// Constant representing the minimum value
     pub const MIN: Self = Integer(i128::MIN);
-    
+
     /// Constant representing the maximum value
     pub const MAX: Self = Integer(i128::MAX);
 
@@ -596,7 +600,7 @@ impl Integer {
     ///
     /// # Parameters
     /// * `x` - The primitive BE integer to convert into Integer
-    /// 
+    ///
     /// # Returns
     /// A new `Integer` containing the converted value.
     pub const fn from_be(x: i128) -> Self {
@@ -626,7 +630,7 @@ impl Integer {
     ///
     /// # Parameters
     /// * `x` - The primitive LE integer to convert into Integer
-    /// 
+    ///
     /// # Returns
     /// A new `Integer` containing the converted value.
     pub const fn from_le(x: i128) -> Self {
@@ -1117,7 +1121,7 @@ impl Integer {
 
     /// Performs saturating exponentiation.
     ///
-    /// Returns the result of exponentiation, saturating at the numeric bounds 
+    /// Returns the result of exponentiation, saturating at the numeric bounds
     /// instead of overflowing.
     ///
     /// # Parameters
@@ -1484,7 +1488,7 @@ impl Integer {
                 return false;
             }
 
-            return true
+            return true;
         }
 
         val >= T::min_value().as_i128() && val <= T::max_value().as_i128()
@@ -2210,7 +2214,7 @@ mod tests {
         assert_eq!(my_i64_int.inner(), 43i128);
         assert_eq!(my_i128_int.inner(), 15i128);
     }
-    
+
     #[test]
     fn test_fits_into_u8() {
         // Values within u8 range
@@ -2218,14 +2222,14 @@ mod tests {
         assert!(Integer(1).fits_into::<u8>());
         assert!(Integer(127).fits_into::<u8>());
         assert!(Integer(255).fits_into::<u8>());
-        
+
         // Values outside u8 range
         assert!(!Integer(-1).fits_into::<u8>());
         assert!(!Integer(256).fits_into::<u8>());
         assert!(!Integer(i128::MAX).fits_into::<u8>());
         assert!(!Integer(i128::MIN).fits_into::<u8>());
     }
-    
+
     #[test]
     fn test_fits_into_i8() {
         // Values within i8 range
@@ -2234,14 +2238,14 @@ mod tests {
         assert!(Integer(0).fits_into::<i8>());
         assert!(Integer(1).fits_into::<i8>());
         assert!(Integer(127).fits_into::<i8>());
-        
+
         // Values outside i8 range
         assert!(!Integer(-129).fits_into::<i8>());
         assert!(!Integer(128).fits_into::<i8>());
         assert!(!Integer(i128::MAX).fits_into::<i8>());
         assert!(!Integer(i128::MIN).fits_into::<i8>());
     }
-    
+
     #[test]
     fn test_fits_into_u16() {
         // Values within u16 range
@@ -2249,14 +2253,14 @@ mod tests {
         assert!(Integer(1).fits_into::<u16>());
         assert!(Integer(32767).fits_into::<u16>());
         assert!(Integer(65535).fits_into::<u16>());
-        
+
         // Values outside u16 range
         assert!(!Integer(-1).fits_into::<u16>());
         assert!(!Integer(65536).fits_into::<u16>());
         assert!(!Integer(i128::MAX).fits_into::<u16>());
         assert!(!Integer(i128::MIN).fits_into::<u16>());
     }
-    
+
     #[test]
     fn test_fits_into_i16() {
         // Values within i16 range
@@ -2265,14 +2269,14 @@ mod tests {
         assert!(Integer(0).fits_into::<i16>());
         assert!(Integer(1).fits_into::<i16>());
         assert!(Integer(32767).fits_into::<i16>());
-        
+
         // Values outside i16 range
         assert!(!Integer(-32769).fits_into::<i16>());
         assert!(!Integer(32768).fits_into::<i16>());
         assert!(!Integer(i128::MAX).fits_into::<i16>());
         assert!(!Integer(i128::MIN).fits_into::<i16>());
     }
-    
+
     #[test]
     fn test_fits_into_u32() {
         // Values within u32 range
@@ -2280,14 +2284,14 @@ mod tests {
         assert!(Integer(1).fits_into::<u32>());
         assert!(Integer(2147483647).fits_into::<u32>());
         assert!(Integer(4294967295).fits_into::<u32>());
-        
+
         // Values outside u32 range
         assert!(!Integer(-1).fits_into::<u32>());
         assert!(!Integer(4294967296).fits_into::<u32>());
         assert!(!Integer(i128::MAX).fits_into::<u32>());
         assert!(!Integer(i128::MIN).fits_into::<u32>());
     }
-    
+
     #[test]
     fn test_fits_into_i32() {
         // Values within i32 range
@@ -2296,14 +2300,14 @@ mod tests {
         assert!(Integer(0).fits_into::<i32>());
         assert!(Integer(1).fits_into::<i32>());
         assert!(Integer(2147483647).fits_into::<i32>());
-        
+
         // Values outside i32 range
         assert!(!Integer(-2147483649).fits_into::<i32>());
         assert!(!Integer(2147483648).fits_into::<i32>());
         assert!(!Integer(i128::MAX).fits_into::<i32>());
         assert!(!Integer(i128::MIN).fits_into::<i32>());
     }
-    
+
     #[test]
     fn test_fits_into_u64() {
         // Values within u64 range
@@ -2311,14 +2315,14 @@ mod tests {
         assert!(Integer(1).fits_into::<u64>());
         assert!(Integer(9223372036854775807).fits_into::<u64>());
         assert!(Integer(18446744073709551615).fits_into::<u64>());
-        
+
         // Values outside u64 range
         assert!(!Integer(-1).fits_into::<u64>());
         assert!(!Integer(18446744073709551616).fits_into::<u64>());
         assert!(!Integer(i128::MAX).fits_into::<u64>());
         assert!(!Integer(i128::MIN).fits_into::<u64>());
     }
-    
+
     #[test]
     fn test_fits_into_i64() {
         // Values within i64 range
@@ -2327,26 +2331,26 @@ mod tests {
         assert!(Integer(0).fits_into::<i64>());
         assert!(Integer(1).fits_into::<i64>());
         assert!(Integer(9223372036854775807).fits_into::<i64>());
-        
+
         // Values outside i64 range
         assert!(!Integer(-9223372036854775809).fits_into::<i64>());
         assert!(!Integer(9223372036854775808).fits_into::<i64>());
         assert!(!Integer(i128::MAX).fits_into::<i64>());
         assert!(!Integer(i128::MIN).fits_into::<i64>());
     }
-    
+
     #[test]
     fn test_fits_into_u128() {
         // Values within u128 range
         assert!(Integer(0).fits_into::<u128>());
         assert!(Integer(1).fits_into::<u128>());
         assert!(Integer(i128::MAX).fits_into::<u128>());
-        
+
         // Values outside u128 range
         assert!(!Integer(-1).fits_into::<u128>());
         assert!(!Integer(i128::MIN).fits_into::<u128>());
     }
-    
+
     #[test]
     fn test_fits_into_i128() {
         // All i128 values fit into i128
@@ -2356,24 +2360,24 @@ mod tests {
         assert!(Integer(1).fits_into::<i128>());
         assert!(Integer(i128::MAX).fits_into::<i128>());
     }
-    
+
     #[test]
     fn test_fits_into_edge_cases() {
         // Test with Integer::MAX and Integer::MIN constants
         assert!(Integer::MIN.fits_into::<i128>());
         assert!(!Integer::MIN.fits_into::<i64>());
         assert!(!Integer::MIN.fits_into::<i32>());
-        
+
         assert!(Integer::MAX.fits_into::<i128>());
         assert!(Integer::MAX.fits_into::<u128>());
         assert!(!Integer::MAX.fits_into::<i64>());
-        
+
         // Test with specific edge values
         let max_i32_plus_1 = Integer(2147483648); // i32::MAX + 1
         assert!(!max_i32_plus_1.fits_into::<i32>());
         assert!(max_i32_plus_1.fits_into::<u32>());
         assert!(max_i32_plus_1.fits_into::<i64>());
-        
+
         let min_i32_minus_1 = Integer(-2147483649); // i32::MIN - 1
         assert!(!min_i32_minus_1.fits_into::<i32>());
         assert!(min_i32_minus_1.fits_into::<i64>());

--- a/src/numbers.rs
+++ b/src/numbers.rs
@@ -4,7 +4,6 @@ use std::{
     cmp::Ordering,
     fmt::{Debug, Display},
     hash::Hash,
-    i128,
     ops::{
         Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Deref,
         DerefMut, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Shl, ShlAssign, Shr,
@@ -1968,7 +1967,7 @@ impl<'de> serde::Deserialize<'de> for Integer {
                 if v.is_ascii() {
                     return Ok(Integer(v as u8 as i128));
                 }
-                if v.is_digit(10) {
+                if v.is_ascii_digit() {
                     return Ok(Integer(v.to_digit(10).unwrap() as i128));
                 }
 
@@ -1994,7 +1993,7 @@ impl<'de> serde::Deserialize<'de> for Integer {
                 }
                 let mut value = 0u128;
                 for c in v.chars() {
-                    if !c.is_digit(10) {
+                    if !c.is_ascii_digit() {
                         return Err(E::custom("invalid character in string"));
                     }
                     value = (value * 10) + (c.to_digit(10).unwrap() as u128);
@@ -2023,7 +2022,7 @@ impl<'de> serde::Deserialize<'de> for Integer {
             where
                 E: serde::de::Error,
             {
-                if v.len() == 0 {
+                if v.is_empty() {
                     return Err(E::custom("empty byte array"));
                 }
                 if v.len() > 16 {


### PR DESCRIPTION
This is a sort-of PoC for how serialization would need to be done for most structs.
This also implements deserization fix for `ClassIdTypeChoice` for the issue described in https://github.com/larrydewey/corim-rs/issues/17
I've also updated the expected value in the `test_cose_sign1_corim_serialize_deserialize` test to both reflect the `ClassMap` change (it now uses integer keys in CBOR), and resture it to make easier to keep updted with changes as we fix up the other structs going foward.

This is implemented on top of https://github.com/larrydewey/corim-rs/pull/15