### PR TITLE
`IntegrityRegisters` serialization and fixes

### DIFF
--- a/src/error/triples.rs
+++ b/src/error/triples.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+use crate::HashAlgorithm;
+
 #[derive(Debug)]
 pub enum TriplesError {
     EmptyTripleRecordCondition,
@@ -7,6 +9,7 @@ pub enum TriplesError {
     EmptyEnvironmentMap,
     EmptyMeasurementValuesMap,
     InvalidIpAddrType,
+    DigestAlreadyExists(String, HashAlgorithm),
     Unknown,
 }
 
@@ -33,6 +36,9 @@ impl std::fmt::Display for TriplesError {
             }
             Self::EmptyTripleRecordCondition => {
                 write!(f, "a TripleRecord must have at least one non-empty field")
+            }
+            Self::DigestAlreadyExists(label, alg) => {
+                write!(f, "{alg} digest for label {label} already exists")
             }
             Self::Unknown => write!(f, "unknown TriplesError encountered"),
         }


### PR DESCRIPTION
Implement `IntegrityRegisters` according to [Section 5.1.4.1.6][1] of the CoRIM spec. The registers are defined to be a mapping of a label to an array of digests (rather than just an array of labels), where different digests associated with a label represent different algorithm hashes of the same measured "object" indicated by the label. This means that

- Algorithms of digests associated with one label must be distinct.
- When checking whether a measured "object" matches the expected digest, it is enough that any one of associated digests match.

The spec also specifies that unsigned integers and string representations of the same (i.e. labels `5` and `"5"`) must be treated as distinct.

[1]: https://www.ietf.org/archive/id/draft-ietf-rats-corim-07.html#section-5.1.4.1.6