### PR TITLE
Human-readable serialization for `MacAddrTypeChoice`

### DIFF
--- a/src/error/triples.rs
+++ b/src/error/triples.rs
@@ -9,6 +9,7 @@ pub enum TriplesError {
     EmptyEnvironmentMap,
     EmptyMeasurementValuesMap,
     InvalidIpAddrType,
+    InvalidMacAddrType,
     DigestAlreadyExists(String, HashAlgorithm),
     Unknown,
 }
@@ -19,6 +20,7 @@ impl std::fmt::Display for TriplesError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::InvalidIpAddrType => write!(f, "invalid IP address type"),
+            Self::InvalidMacAddrType => write!(f, "invalid MAC address type"),
             Self::EmptyMeasurementValuesMap => {
                 write!(
                     f,


### PR DESCRIPTION
- Implement `From<&str>` and `Display` for `MacAddrTypeChoice` using
  hyphen-delimited hex bytes as the string representation (as per [IEEE
  guidelines][1]).
- serialize as string when the format is human-readable and as bytes
  when not.

Note: this is implemented on top of https://github.com/larrydewey/corim-rs/pull/25

[1]: https://standards.ieee.org/wp-content/uploads/import/documents/tutorials/eui.pdf