### PR TITLE
`ExtensionValue::Tag` and `MeasuredElementTypeChoice` and `ClassIdTypeChoice` extensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,8 @@ derive_more = { version = "^2", features = [
 base64 = "0.22.1"
 oid = { version = "0.2.1", features = ["serde", "serde_support"] }
 uuid = "1.16.0"
-serde_json = {version = "1.0.140", features = ["raw_value"]}
+serde_json = {version = "1.0.140", features = [
+    "raw_value",
+    "arbitrary_precision",
+]}
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -468,7 +468,10 @@ impl TryFrom<serde_json::Value> for ExtensionValue<'_> {
                     ))
                 }
             }
-            serde_json::Value::String(s) => Ok(Self::Text(s.into())),
+            serde_json::Value::String(s) => match URL_SAFE_NO_PAD.decode(&s) {
+                Ok(bytes) => Ok(Self::Bytes(bytes.into())),
+                Err(_) => Ok(Self::Text(s.into())),
+            },
             serde_json::Value::Array(a) => Ok(Self::Array(
                 a.into_iter()
                     .map(Self::try_from)


### PR DESCRIPTION
- Add `ExtensionValue::Tag` variant to support CBOR tags (most type choice extensions are expected to be tagged).
- Add extensions support to `MeasuredElementTypeChoice`
- Add extensions support to `ClassIdTypeChoice`

This partially address https://github.com/larrydewey/corim-rs/issues/28

NOTE: this is implemented on top of https://github.com/larrydewey/corim-rs/pull/29 