### PR TITLE
A number of fixes due to recent changes in dependencies/cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,21 +89,22 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn",
 ]
 
@@ -238,10 +239,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"

--- a/src/comid.rs
+++ b/src/comid.rs
@@ -200,7 +200,7 @@ impl<'a> ConciseMidTag<'a> {
     {
         let mut raw_bytes = vec![];
         ciborium::into_writer(value, &mut raw_bytes)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
         let raw_value = TaggedBytes::new(raw_bytes.into());
 
         let measurement = MeasurementMap {
@@ -289,7 +289,7 @@ impl<'a> ConciseMidTag<'a> {
     {
         let mut raw_bytes = vec![];
         ciborium::into_writer(value, &mut raw_bytes)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
         let raw_value = TaggedBytes::new(raw_bytes.into());
 
         let measurement = MeasurementMap {
@@ -1464,7 +1464,7 @@ impl Serialize for TriplesMap<'_> {
         let is_human_readable = serializer.is_human_readable();
         let len = map_len!(
             self,
-            0 + self.extensions.as_ref().map_or(0, |e| e.len()),
+            self.extensions.as_ref().map_or(0, |e| e.len()),
             reference_triples,
             endorsed_triples,
             identity_triples,

--- a/src/comid.rs
+++ b/src/comid.rs
@@ -94,7 +94,7 @@ use crate::{
     DomainMembershipTripleRecord, Empty as _, EndorsedTripleRecord, ExtensionMap, ExtensionValue,
     IdentityTripleRecord, Integer, ReferenceTripleRecord, Result, Text, Tstr, Uint, Uri, UuidType,
 };
-use derive_more::{Constructor, From, TryFrom};
+use derive_more::{Constructor, From};
 use serde::{
     de::{self, Visitor},
     ser::SerializeMap,
@@ -696,7 +696,7 @@ impl<'de> Deserialize<'de> for TagIdentityMap<'_> {
 /// This enum allows CoMID tags to be identified by either a text string
 /// or a UUID, following the schema definition in the CoRIM specification.
 /// Tag identifiers are used in the tag identity map and for linking between tags.
-#[derive(Debug, Serialize, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, Serialize, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[repr(C)]
 #[serde(untagged)]
 pub enum TagIdTypeChoice<'a> {
@@ -1091,7 +1091,7 @@ impl Default for ComidEntityMapBuilder<'_> {
 ///
 /// Each role type represents a specific responsibility that an entity
 /// may have in relation to a module or tag.
-#[derive(Debug, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[repr(i64)]
 pub enum ComidRoleTypeChoice {
     /// Entity that created the tag (value: 0)
@@ -1319,7 +1319,7 @@ impl<'de> Deserialize<'de> for LinkedTagMap<'_> {
 ///
 /// This enum defines how tags can be related to each other,
 /// supporting versioning and supplemental information scenarios.
-#[derive(Debug, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[repr(C)]
 pub enum TagRelTypeChoice {
     /// This tag supplements the linked tag by providing additional information

--- a/src/comid.rs
+++ b/src/comid.rs
@@ -761,14 +761,14 @@ impl TagIdTypeChoice<'_> {
         }
     }
 
-    pub fn as_ref_extension(&self) -> Option<&ExtensionValue> {
+    pub fn as_ref_extension(&self) -> Option<&ExtensionValue<'_>> {
         match self {
             Self::Extension(ext) => Some(ext),
             _ => None,
         }
     }
 
-    pub fn as_extension(&self) -> Option<ExtensionValue> {
+    pub fn as_extension(&self) -> Option<ExtensionValue<'_>> {
         match self {
             Self::Extension(ext) => Some(ext.clone()),
             _ => None,

--- a/src/core.rs
+++ b/src/core.rs
@@ -288,6 +288,7 @@ impl<'a, 'b> ExtensionMap<'a> {
     }
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl<'a> ExtensionMap<'a> {
     pub fn new() -> Self {
         Self::default()

--- a/src/core.rs
+++ b/src/core.rs
@@ -2104,7 +2104,7 @@ impl<'a> AttributeValue<'a> {
         }
     }
 
-    pub fn as_text(&self) -> Option<&OneOrMore<Text>> {
+    pub fn as_text(&self) -> Option<&OneOrMore<Text<'_>>> {
         match self {
             Self::Text(val) => Some(val),
             _ => None,

--- a/src/core.rs
+++ b/src/core.rs
@@ -324,7 +324,7 @@ impl Empty for ExtensionMap<'_> {
 }
 
 /// ExtensionMap represents the possible types that can be used in extensions
-#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, TryFrom, Clone)]
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone)]
 pub enum ExtensionValue<'a> {
     /// No value
     Null,
@@ -1371,7 +1371,7 @@ impl From<CoseKey> for CoseKeyType {
 
 /// Represents a value that can be either text or bytes
 #[repr(C)]
-#[derive(Debug, Serialize, Deserialize, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, Serialize, Deserialize, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[serde(untagged)]
 pub enum TextOrBytes<'a> {
     /// UTF-8 string value
@@ -1418,7 +1418,7 @@ impl<'a> From<&'a str> for TextOrBytes<'a> {
 
 /// Represents a value that can be either text or fixed-size bytes
 #[repr(C)]
-#[derive(Debug, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum TextOrBytesSized<'a, const N: usize> {
     /// UTF-8 string value
     Text(Text<'a>),
@@ -1533,7 +1533,7 @@ pub type HashEntry = Digest;
 
 /// Represents a label that can be either text or integer
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, From, TryFrom)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, From)]
 #[serde(untagged)]
 pub enum Label<'a> {
     /// Text label
@@ -1645,7 +1645,7 @@ impl Display for Label<'_> {
 
 /// Represents an unsigned label that can be either text or unsigned integer
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, From, TryFrom)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, From)]
 pub enum Ulabel<'a> {
     /// Text label
     Text(Text<'a>),
@@ -1818,7 +1818,7 @@ impl<'de> Deserialize<'de> for Ulabel<'_> {
 }
 
 /// Represents one or more values that can be either text or integers
-#[derive(Debug, Clone, PartialEq, Serialize, Eq, PartialOrd, Ord, TryFrom)]
+#[derive(Debug, Clone, PartialEq, Serialize, Eq, PartialOrd, Ord)]
 #[serde(untagged)]
 #[repr(C)]
 pub enum OneOrMore<T> {
@@ -2059,7 +2059,7 @@ impl AttributeMap<'_> {
 
 /// Represents the value of a global attribute. Either one or more integers, or one or more text
 /// strings.
-#[derive(Debug, Clone, PartialEq, Serialize, Eq, PartialOrd, Ord, From, TryFrom)]
+#[derive(Debug, Clone, PartialEq, Serialize, Eq, PartialOrd, Ord, From)]
 #[serde(untagged)]
 #[repr(C)]
 pub enum AttributeValue<'a> {
@@ -2452,6 +2452,7 @@ impl Empty for GlobalAttributes<'_> {
 
 /// Registry of valid keys for CoRIM maps according to the specification
 #[derive(Debug, Serialize, Deserialize, From, TryFrom)]
+#[try_from(repr)]
 #[repr(C)]
 #[serde(untagged)]
 pub enum CorimMapRegistry {
@@ -2471,6 +2472,7 @@ pub enum CorimMapRegistry {
 
 /// Registry of valid keys for CoMID maps according to the specification
 #[derive(Debug, Serialize, Deserialize, From, TryFrom)]
+#[try_from(repr)]
 #[repr(C)]
 #[serde(untagged)]
 pub enum ComidMapRegistry {
@@ -2488,6 +2490,7 @@ pub enum ComidMapRegistry {
 
 /// Registry of valid keys for CoTL maps according to the specification
 #[derive(Debug, Serialize, Deserialize, From, TryFrom)]
+#[try_from(repr)]
 #[repr(C)]
 #[serde(untagged)]
 pub enum CotlMapRegistry {
@@ -2612,7 +2615,7 @@ impl<'de> Deserialize<'de> for Digest {
 }
 /// Represents either a COSE key set or a single COSE key
 #[repr(C)]
-#[derive(Debug, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum CoseKeySetOrKey {
     /// A set of COSE keys
     KeySet(Vec<CoseKey>),
@@ -3641,7 +3644,7 @@ impl<'de> Deserialize<'de> for RawValueTypeChoice<'_> {
 
 /// Version scheme enumeration as defined in the specification
 #[repr(i64)]
-#[derive(Debug, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum VersionScheme<'a> {
     /// Multi-part numeric version (e.g., 1.2.3)
     Multipartnumeric = 1,
@@ -3875,6 +3878,7 @@ impl<'de> Deserialize<'de> for VersionScheme<'_> {
 /// ```
 #[repr(i8)]
 #[derive(Debug, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[try_from(repr)]
 pub enum HashAlgorithm {
     Sha256 = 1,
     Sha256_128 = 2,
@@ -4164,7 +4168,7 @@ impl<'de> Deserialize<'de> for HashAlgorithm {
 /// let alg = CoseAlgorithm::ES256;  // ECDSA with SHA-256
 /// let hash_alg = CoseAlgorithm::Sha256;  // SHA-256 hash function
 /// ```
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, TryFrom)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord )]
 #[repr(i64)]
 pub enum CoseAlgorithm {
     // Reserved for Private Use
@@ -4710,7 +4714,7 @@ impl<'de> Deserialize<'de> for CoseAlgorithm {
 /// let okp = CoseKty::Okp;  // Octet Key Pair
 /// let ec2 = CoseKty::Ec2;  // Elliptic Curve w/ x/y coordinates
 /// ```
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, TryFrom)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i8)]
 pub enum CoseKty {
     // key type is invalid/has not been set
@@ -4833,7 +4837,7 @@ impl<'de> Deserialize<'de> for CoseKty {
 /// let sign = CoseKeyOperation::Sign;  // key used for signing
 /// let verify = CoseKeyOperation::Verify;  // key used for verification of signatures
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, TryFrom)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i8)]
 pub enum CoseKeyOperation {
     /// The key is used to create signatures. Requires private key fields.
@@ -5045,7 +5049,7 @@ impl<'de> Deserialize<'de> for CoseKeyOperation {
 /// let curve1 = CoseEllipticCurve::P256; // NIST P-256 curve, EC2 keys
 /// let curve2 = CoseEllipticCurve::Ed25519; // Ed25519 EdDSA curve, OKP keys
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, TryFrom)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i64)]
 pub enum CoseEllipticCurve {
     /// Private Use

--- a/src/corim.rs
+++ b/src/corim.rs
@@ -1082,42 +1082,42 @@ impl<'de> Deserialize<'de> for ConciseTagTypeChoice<'_> {
 }
 
 impl ConciseTagTypeChoice<'_> {
-    pub fn as_coswid(&self) -> Option<ConciseSwidTag> {
+    pub fn as_coswid(&self) -> Option<ConciseSwidTag<'_>> {
         match self {
             Self::Swid(coswid) => Some(coswid.as_ref().clone()),
             _ => None,
         }
     }
 
-    pub fn as_comid(&self) -> Option<ConciseMidTag> {
+    pub fn as_comid(&self) -> Option<ConciseMidTag<'_>> {
         match self {
             Self::Mid(comid) => Some(comid.as_ref().clone()),
             _ => None,
         }
     }
 
-    pub fn as_cotl(&self) -> Option<ConciseTlTag> {
+    pub fn as_cotl(&self) -> Option<ConciseTlTag<'_>> {
         match self {
             Self::Tl(cotl) => Some(cotl.as_ref().clone()),
             _ => None,
         }
     }
 
-    pub fn as_ref_coswid(&self) -> Option<&ConciseSwidTag> {
+    pub fn as_ref_coswid(&self) -> Option<&ConciseSwidTag<'_>> {
         match self {
             Self::Swid(coswid) => Some(coswid.as_ref()),
             _ => None,
         }
     }
 
-    pub fn as_ref_comid(&self) -> Option<&ConciseMidTag> {
+    pub fn as_ref_comid(&self) -> Option<&ConciseMidTag<'_>> {
         match self {
             Self::Mid(comid) => Some(comid.as_ref()),
             _ => None,
         }
     }
 
-    pub fn as_ref_cotl(&self) -> Option<&ConciseTlTag> {
+    pub fn as_ref_cotl(&self) -> Option<&ConciseTlTag<'_>> {
         match self {
             Self::Tl(cotl) => Some(cotl.as_ref()),
             _ => None,
@@ -1295,14 +1295,14 @@ impl<'a> ProfileTypeChoice<'a> {
         matches!(self, Self::Extension(_))
     }
 
-    pub fn as_uri(&self) -> Option<Uri> {
+    pub fn as_uri(&self) -> Option<Uri<'_>> {
         match self {
             Self::Uri(uri) => Some(uri.clone()),
             _ => None,
         }
     }
 
-    pub fn as_ref_uri(&self) -> Option<&Uri> {
+    pub fn as_ref_uri(&self) -> Option<&Uri<'_>> {
         match self {
             Self::Uri(uri) => Some(uri),
             _ => None,

--- a/src/corim.rs
+++ b/src/corim.rs
@@ -190,7 +190,7 @@ use crate::{
 };
 
 use coset::{iana::EnumI64 as _, AsCborValue as _, CoseSign1};
-use derive_more::{Constructor, From, TryFrom};
+use derive_more::{Constructor, From};
 use serde::{
     de::{self, Visitor},
     ser::{self, SerializeMap},
@@ -203,7 +203,7 @@ pub type UnsignedCorimMap<'a> = CorimMap<'a>;
 
 /// A type choice representing either a signed or unsigned CoRIM manifest
 #[repr(C)]
-#[derive(Debug, From, TryFrom)]
+#[derive(Debug, From)]
 #[allow(clippy::large_enum_variant)]
 pub enum ConciseRimTypeChoice<'a> {
     /// An unprotected CoRIM with CBOR tag 501
@@ -784,7 +784,7 @@ impl<'a> CorimMapBuilder<'a> {
 
 /// Represents either a string or UUID identifier for a CoRIM
 #[repr(C)]
-#[derive(Debug, Serialize, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, Serialize, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[serde(untagged)]
 pub enum CorimIdTypeChoice<'a> {
     /// Text string identifier
@@ -868,7 +868,7 @@ impl<'de> Deserialize<'de> for CorimIdTypeChoice<'_> {
 
 /// Types of tags that can be included in a CoRIM
 #[repr(C)]
-#[derive(Debug, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum ConciseTagTypeChoice<'a> {
     /// A Concise Software Identity (CoSWID) tag
     Swid(TaggedConciseSwidTag<'a>),
@@ -1261,7 +1261,7 @@ impl<'de> Deserialize<'de> for CorimLocatorMap<'_> {
 
 /// Profile identifier that can be either a URI or OID
 #[repr(C)]
-#[derive(Debug, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum ProfileTypeChoice<'a> {
     /// URI-based profile identifier
     Uri(Uri<'a>),
@@ -1775,7 +1775,7 @@ impl Default for CorimEntityMapBuilder<'_> {
 }
 
 /// Roles that entities can have in relation to a CoRIM manifest
-#[derive(Debug, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[repr(i64)]
 pub enum CorimRoleTypeChoice {
     /// Entity that created the manifest content
@@ -2622,7 +2622,7 @@ impl<'de> Deserialize<'de> for CorimSignerMap<'_> {
 
 /// Type alias for entity names using text strings
 #[repr(C)]
-#[derive(Debug, Serialize, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, Serialize, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[serde(untagged)]
 pub enum EntityNameTypeChoice<'a> {
     Text(Text<'a>),

--- a/src/corim.rs
+++ b/src/corim.rs
@@ -867,6 +867,7 @@ impl<'de> Deserialize<'de> for CorimIdTypeChoice<'_> {
 }
 
 /// Types of tags that can be included in a CoRIM
+#[allow(clippy::large_enum_variant)]
 #[repr(C)]
 #[derive(Debug, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum ConciseTagTypeChoice<'a> {

--- a/src/coswid.rs
+++ b/src/coswid.rs
@@ -78,7 +78,7 @@ use crate::{
     ExtensionValue, GlobalAttributes, HashEntry, Int, Integer, IntegerTime, Label, OneOrMore, Text,
     TextOrBytes, TextOrBytesSized, Uint, Uri, VersionScheme,
 };
-use derive_more::{Constructor, From, TryFrom};
+use derive_more::{Constructor, From};
 use serde::{
     de::{self, Visitor},
     ser::{self, SerializeMap},
@@ -1305,7 +1305,7 @@ impl<'a> SoftwareMetaEntryBuilder<'a> {
     }
 }
 
-#[derive(Debug, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[repr(u8)]
 pub enum Role<'a> {
     TagCreator = 1,
@@ -2189,7 +2189,7 @@ impl<'a> LinkEntryBuilder<'a> {
 }
 
 /// Ownership status enumeration for linked resources
-#[derive(Debug, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[repr(u8)]
 pub enum Ownership<'a> {
     /// Resource is no longer maintained
@@ -2332,7 +2332,7 @@ impl<'de> Deserialize<'de> for Ownership<'_> {
 }
 
 /// Relationship types between resources in CoSWID tags
-#[derive(Debug, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[repr(u8)]
 pub enum Rel<'a> {
     /// Previous version of the software
@@ -4928,7 +4928,7 @@ impl<'a> EvidenceEntryBuilder<'a> {
 }
 
 /// Usage requirement levels for resources
-#[derive(Debug, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[repr(u8)]
 pub enum Use<'a> {
     /// Resource is optional

--- a/src/triples.rs
+++ b/src/triples.rs
@@ -873,6 +873,7 @@ impl<'de> Deserialize<'de> for ClassIdTypeChoice<'_> {
 }
 
 /// Possible types for instance identifiers
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Serialize, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[repr(C)]
 #[serde(untagged)]
@@ -3387,7 +3388,7 @@ impl Serialize for FlagsMap<'_> {
 
         let len = map_len!(
             self,
-            0 + self.extensions.as_ref().map_or(0, |e| e.len()),
+            self.extensions.as_ref().map_or(0, |e| e.len()),
             is_configured,
             is_secure,
             is_recovery,

--- a/src/triples.rs
+++ b/src/triples.rs
@@ -941,14 +941,14 @@ impl InstanceIdTypeChoice<'_> {
         }
     }
 
-    pub fn as_crypto_key(&self) -> Option<CryptoKeyTypeChoice> {
+    pub fn as_crypto_key(&self) -> Option<CryptoKeyTypeChoice<'_>> {
         match self {
             Self::CryptoKey(key) => Some(key.clone()),
             _ => None,
         }
     }
 
-    pub fn as_ref_crypto_key(&self) -> Option<&CryptoKeyTypeChoice> {
+    pub fn as_ref_crypto_key(&self) -> Option<&CryptoKeyTypeChoice<'_>> {
         match self {
             Self::CryptoKey(key) => Some(key),
             _ => None,
@@ -962,14 +962,14 @@ impl InstanceIdTypeChoice<'_> {
         }
     }
 
-    pub fn as_ref_extension(&self) -> Option<&ExtensionValue> {
+    pub fn as_ref_extension(&self) -> Option<&ExtensionValue<'_>> {
         match self {
             Self::Extension(ext) => Some(ext),
             _ => None,
         }
     }
 
-    pub fn as_extension(&self) -> Option<ExtensionValue> {
+    pub fn as_extension(&self) -> Option<ExtensionValue<'_>> {
         match self {
             Self::Extension(ext) => Some(ext.clone()),
             _ => None,
@@ -1403,42 +1403,42 @@ impl CryptoKeyTypeChoice<'_> {
         matches!(self, Self::Extension(_))
     }
 
-    pub fn as_pkix_key(&self) -> Option<PkixBase64KeyType> {
+    pub fn as_pkix_key(&self) -> Option<PkixBase64KeyType<'_>> {
         match self {
             Self::PkixBase64Key(key) => Some(key.clone()),
             _ => None,
         }
     }
 
-    pub fn as_ref_pkix_key(&self) -> Option<&PkixBase64KeyType> {
+    pub fn as_ref_pkix_key(&self) -> Option<&PkixBase64KeyType<'_>> {
         match self {
             Self::PkixBase64Key(key) => Some(key),
             _ => None,
         }
     }
 
-    pub fn as_pkix_cert(&self) -> Option<PkixBase64CertType> {
+    pub fn as_pkix_cert(&self) -> Option<PkixBase64CertType<'_>> {
         match self {
             Self::PkixBase64Cert(cert) => Some(cert.clone()),
             _ => None,
         }
     }
 
-    pub fn as_ref_pkix_cert(&self) -> Option<&PkixBase64CertType> {
+    pub fn as_ref_pkix_cert(&self) -> Option<&PkixBase64CertType<'_>> {
         match self {
             Self::PkixBase64Cert(cert) => Some(cert),
             _ => None,
         }
     }
 
-    pub fn as_pkix_cert_path(&self) -> Option<PkixBase64CertPathType> {
+    pub fn as_pkix_cert_path(&self) -> Option<PkixBase64CertPathType<'_>> {
         match self {
             Self::PkixBase64CertPath(cert_path) => Some(cert_path.clone()),
             _ => None,
         }
     }
 
-    pub fn as_ref_pkix_cert_path(&self) -> Option<&PkixBase64CertPathType> {
+    pub fn as_ref_pkix_cert_path(&self) -> Option<&PkixBase64CertPathType<'_>> {
         match self {
             Self::PkixBase64CertPath(cert_path) => Some(cert_path),
             _ => None,
@@ -1522,7 +1522,7 @@ impl CryptoKeyTypeChoice<'_> {
         }
     }
 
-    pub fn as_extension(&self) -> Option<&ExtensionValue> {
+    pub fn as_extension(&self) -> Option<&ExtensionValue<'_>> {
         match self {
             Self::Extension(ext) => Some(ext),
             _ => None,
@@ -1777,14 +1777,14 @@ impl GroupIdTypeChoice<'_> {
         }
     }
 
-    pub fn as_ref_extension(&self) -> Option<&ExtensionValue> {
+    pub fn as_ref_extension(&self) -> Option<&ExtensionValue<'_>> {
         match self {
             Self::Extension(ext) => Some(ext),
             _ => None,
         }
     }
 
-    pub fn as_extension(&self) -> Option<ExtensionValue> {
+    pub fn as_extension(&self) -> Option<ExtensionValue<'_>> {
         match self {
             Self::Extension(ext) => Some(ext.clone()),
             _ => None,
@@ -4019,7 +4019,7 @@ impl IntegrityRegisters<'_> {
     }
 
     /// Iterate over (Ulabel, Vec<Digest>) tuples contained in the IntegrityRegisters.
-    pub fn iter(&self) -> Iter<'_, Ulabel, Vec<Digest>> {
+    pub fn iter(&self) -> Iter<'_, Ulabel<'_>, Vec<Digest>> {
         self.0.iter()
     }
 

--- a/src/triples.rs
+++ b/src/triples.rs
@@ -108,7 +108,7 @@ use crate::{
     TaggedBytes, TaggedUeidType, TaggedUuidType, Text, ThumbprintType, TriplesError, Tstr,
     UeidType, Uint, Ulabel, UuidType, VersionScheme,
 };
-use derive_more::{Constructor, From, TryFrom};
+use derive_more::{Constructor, From};
 use serde::{
     de::{self, SeqAccess, Visitor},
     ser::{self, SerializeMap, SerializeSeq},
@@ -614,7 +614,7 @@ impl<'a> ClassMapBuilder<'a> {
 }
 
 /// Possible types for class identifiers
-#[derive(Debug, Serialize, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, Serialize, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[repr(C)]
 #[serde(untagged)]
 pub enum ClassIdTypeChoice<'a> {
@@ -873,7 +873,7 @@ impl<'de> Deserialize<'de> for ClassIdTypeChoice<'_> {
 }
 
 /// Possible types for instance identifiers
-#[derive(Debug, Serialize, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, Serialize, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[repr(C)]
 #[serde(untagged)]
 pub enum InstanceIdTypeChoice<'a> {
@@ -1308,7 +1308,7 @@ impl<'de> Deserialize<'de> for InstanceIdTypeChoice<'_> {
 ///
 /// Each variant provides appropriate constructors and implements common traits
 /// like `From`, `TryFrom`, `Serialize`, and `Deserialize`.
-#[derive(Debug, Serialize, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, Serialize, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[repr(C)]
 #[serde(untagged)]
 pub enum CryptoKeyTypeChoice<'a> {
@@ -1727,7 +1727,7 @@ impl<'de> Deserialize<'de> for CryptoKeyTypeChoice<'_> {
 }
 
 /// Types of group identifiers
-#[derive(Debug, Serialize, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, Serialize, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[repr(C)]
 #[serde(untagged)]
 pub enum GroupIdTypeChoice<'a> {
@@ -2044,7 +2044,7 @@ impl<'de> Deserialize<'de> for MeasurementMap<'_> {
 }
 
 /// Types of measured element identifiers
-#[derive(Debug, Serialize, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, Serialize, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[repr(C)]
 #[serde(untagged)]
 pub enum MeasuredElementTypeChoice<'a> {
@@ -3055,7 +3055,7 @@ impl<'de> Deserialize<'de> for VersionMap<'_> {
 }
 
 /// Security version number types
-#[derive(Debug, Serialize, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, Serialize, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[repr(C)]
 #[serde(untagged)]
 pub enum SvnTypeChoice {
@@ -4597,7 +4597,7 @@ impl<'de> Deserialize<'de> for DomainDependencyTripleRecord<'_> {
 }
 
 /// Types of domain identifiers
-#[derive(Debug, Serialize, From, TryFrom, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, Serialize, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[serde(untagged)]
 pub enum DomainTypeChoice<'a> {
     /// Unsigned integer identifier


### PR DESCRIPTION
- Fix `derive_more` issues that started being reproted by the recent versions of the crate
- Fix clippy/compiler warnings that are now reproted by `cargo`

Addresses: https://github.com/veraison/corim-rs/issues/45