### PR TITLE
fix(build): update openssl depencency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,22 +168,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -210,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,6 @@ serde_json = {version = "1.0.140", features = [
     "arbitrary_precision",
 ]}
 coset = { version = "0.3.8", features = ["std"] }
-openssl = { version = "0.10", features = ["vendored"], optional=true}
+openssl = { version = "0.10.79", features = ["vendored"], optional=true}
 either = "1.15.0"
 


### PR DESCRIPTION
Update the version of openssl we depend on to mitigate vulnerabilities in earlier versions identified by dependabot.