### PR TITLE
fix(core): cbor deserialization of Bytes

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -278,8 +278,7 @@ impl<'de> Deserialize<'de> for Bytes {
             // ostensibly human-readable formats.
             deserializer.deserialize_any(BytesVisitor)
         } else {
-            let bytes = Vec::<u8>::deserialize(deserializer)?;
-            Ok(Bytes { bytes })
+            deserializer.deserialize_bytes(BytesVisitor)
         }
     }
 }
@@ -5414,6 +5413,20 @@ mod tests {
             let actual: super::Bytes = serde_json::from_str(text).unwrap();
 
             assert_eq!(actual, expected);
+        }
+
+        #[test]
+        fn test_bytes_de() {
+            let arr: Vec<u8> = vec![0x81, 0x00];
+            let bstr: Vec<u8> = vec![0x41, 0x00];
+
+            let a = ciborium::from_reader::<super::Bytes, &[u8]>(arr.as_slice());
+            let b = ciborium::from_reader::<super::Bytes, &[u8]>(bstr.as_slice());
+
+            assert!(a.is_err(), "CBOR array should not deserialize as Bytes");
+            assert!(b.is_ok(), "CBOR bytes should deserialize as Bytes");
+
+            assert_eq!(b.unwrap(), super::Bytes { bytes: vec![0] });
         }
     }
 


### PR DESCRIPTION
In the non-humanreadable flow, raw bytes were being serialized using Vec::<u8>::deserialize, which uses Deserializer::deserialize_seq (https://docs.rs/serde/latest/src/serde/core/de/impls.rs.html#1175). But the deserializer may not recognize a byte string as sequence of u8.

For example, the bytes
0x44, 0x01, 0x02, 0x03, 0x04 // cbor bytes
and
0x84, 0x01, 0x02, 0x03, 0x04 // cbor array of integers both deserialize into {bytes: Vec<u8>}