### PR TITLE
chore: fix pre-existing clippy lints on master

### DIFF
--- a/src/comid.rs
+++ b/src/comid.rs
@@ -87,7 +87,6 @@
 
 use crate::{
     core::{RawValueType, TaggedBytes},
-    generate_tagged,
     triples::{EnvironmentMap, MeasuredElementTypeChoice, MeasurementMap, MeasurementValuesMap},
     AttestKeyTripleRecord, ComidError, ConditionalEndorsementSeriesTripleRecord,
     ConditionalEndorsementTripleRecord, CoswidTripleRecord, DomainDependencyTripleRecord,

--- a/src/core.rs
+++ b/src/core.rs
@@ -53,7 +53,7 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
-use crate::{empty::Empty, error::CoreError, generate_tagged, FixedBytes, Integer};
+use crate::{empty::Empty, error::CoreError, FixedBytes, Integer};
 
 /// Text represents a UTF-8 string value
 pub type Text<'a> = Cow<'a, str>;
@@ -6413,7 +6413,7 @@ mod tests {
                     ExtensionValue::Uint(1.into()),
                     ExtensionValue::Uint(2.into()),
                     ExtensionValue::Uint(3.into()),
-                ].into()),
+                ]),
                 expected_json: "[1,2,3]",
                 expected_cbor: vec![
                     0x83, // array(3)

--- a/src/corim.rs
+++ b/src/corim.rs
@@ -187,7 +187,6 @@ use crate::{
     coswid::ConciseSwidTag,
     cotl::ConciseTlTag,
     error::CorimError,
-    generate_tagged,
     numbers::Integer,
     Digest, Empty, ExtensionMap, ExtensionValue, OidType, TaggedBytes, TaggedConciseMidTag,
     TaggedConciseSwidTag, TaggedConciseTlTag, Text, Tstr, Uri, UuidType,

--- a/src/coswid.rs
+++ b/src/coswid.rs
@@ -74,7 +74,7 @@
 use std::{fmt::Display, marker::PhantomData};
 
 use crate::{
-    error::CoswidError, generate_tagged, AnyUri, AttributeValue, Empty, ExtensionMap,
+    error::CoswidError, AnyUri, AttributeValue, Empty, ExtensionMap,
     ExtensionValue, GlobalAttributes, HashEntry, Int, Integer, IntegerTime, Label, OneOrMore, Text,
     TextOrBytes, TextOrBytesSized, Uint, Uri, VersionScheme,
 };
@@ -771,7 +771,7 @@ impl Serialize for SoftwareMetaEntry<'_> {
         let is_human_readable = serializer.is_human_readable();
         let len = map_len!(
             self,
-            0 + self.extensions.as_ref().map_or(0, |e| e.len())
+            self.extensions.as_ref().map_or(0, |e| e.len())
                 + self.global_attributes.as_ref().map_or(0, |a| a.len()),
             activation_status,
             channel_type,
@@ -2938,6 +2938,10 @@ impl ResourceCollection<'_> {
         ret
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn serialize_map<M, O, E>(&self, map: &mut M, is_human_readable: bool) -> Result<(), E>
     where
         M: ser::SerializeMap<Ok = O, Error = E>,
@@ -3214,6 +3218,10 @@ impl PathElementsGroup<'_> {
         }
 
         ret
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     pub fn serialize_map<M, O, E>(&self, map: &mut M, is_human_readable: bool) -> Result<(), E>
@@ -3727,6 +3735,11 @@ impl FileSystemItem<'_> {
     pub fn len(&self) -> usize {
         map_len!(self, 1, key, location, root)
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn serialize_map<M, O, E>(&self, map: &mut M, is_human_readable: bool) -> Result<(), E>
     where
         M: ser::SerializeMap<Ok = O, Error = E>,

--- a/src/cotl.rs
+++ b/src/cotl.rs
@@ -10,7 +10,7 @@ use serde::{
 };
 
 use crate::{
-    generate_tagged, CotlError, IntegerTime, TagIdTypeChoice, TagIdentityMap, TagVersionType,
+    CotlError, IntegerTime, TagIdTypeChoice, TagIdentityMap, TagVersionType,
     ValidityMap,
 };
 

--- a/src/numbers.rs
+++ b/src/numbers.rs
@@ -2054,8 +2054,6 @@ impl<'de> serde::Deserialize<'de> for Integer {
 
 #[cfg(test)]
 mod tests {
-    use std::u32;
-
     use super::*;
 
     #[test]

--- a/src/openssl.rs
+++ b/src/openssl.rs
@@ -121,18 +121,15 @@ impl CoseSigner for OpensslSigner {
             }
         };
 
-        let key_bytes;
-        let key_number;
-        let group;
-        match self.key.kty {
+        let (key_bytes, key_number, group) = match self.key.kty {
             CoseKty::Ec2 => {
-                if self.key.d.is_none() {
-                    return Err(CorimError::custom("key missing private component d"));
-                }
-
-                key_bytes = self.key.d.as_ref().unwrap();
-                key_number = BigNum::from_slice(key_bytes).map_err(CorimError::custom)?;
-                group = match self
+                let key_bytes = self
+                    .key
+                    .d
+                    .as_ref()
+                    .ok_or_else(|| CorimError::custom("key missing private component d"))?;
+                let key_number = BigNum::from_slice(key_bytes).map_err(CorimError::custom)?;
+                let group = match self
                     .key
                     .crv
                     .as_ref()
@@ -148,10 +145,11 @@ impl CoseSigner for OpensslSigner {
                             other.to_string(),
                         ));
                     }
-                }
+                };
+                (key_bytes, key_number, group)
             }
             other => return Err(CorimError::Custom(format!("unsupported key type {other}"))),
-        }
+        };
 
         let ec_key =
             EcKey::from_private_components(&group, &key_number, &EcPoint::new(&group).unwrap())?;
@@ -188,29 +186,28 @@ impl CoseVerifier for OpensslSigner {
             }
         };
 
-        let size;
-        let group;
-        let mut pub_key_bytes;
-        match self.key.kty {
+        let (size, group, pub_key_bytes) = match self.key.kty {
             CoseKty::Ec2 => {
                 if self.key.y.is_none() {
                     return Err(CorimError::custom("key missing public component x"));
                 }
 
                 let mut x = self.key.x.as_ref().unwrap().to_vec();
-                size = x.len();
+                let size = x.len();
 
-                if self.key.y.is_some() && self.key.y.as_ref().unwrap().len() > 0 {
+                let pub_key_bytes = if self.key.y.as_ref().is_some_and(|y| !y.is_empty()) {
                     let mut y = self.key.y.as_ref().unwrap().to_vec();
-                    pub_key_bytes = vec![4]; // SEC1 EC2 no point compression
+                    let mut pub_key_bytes = vec![4]; // SEC1 EC2 no point compression
                     pub_key_bytes.append(&mut x);
                     pub_key_bytes.append(&mut y);
+                    pub_key_bytes
                 } else {
-                    pub_key_bytes = vec![3]; // SEC1 EC2 w/ point compression
+                    let mut pub_key_bytes = vec![3]; // SEC1 EC2 w/ point compression
                     pub_key_bytes.append(&mut x);
-                }
+                    pub_key_bytes
+                };
 
-                group = match self
+                let group = match self
                     .key
                     .crv
                     .as_ref()
@@ -226,10 +223,11 @@ impl CoseVerifier for OpensslSigner {
                             other.to_string(),
                         ));
                     }
-                }
+                };
+                (size, group, pub_key_bytes)
             }
             other => return Err(CorimError::Custom(format!("unsupported key type {other}"))),
-        }
+        };
 
         let mut ctx = BigNumContext::new()?;
         let point = EcPoint::from_bytes(&group, &pub_key_bytes, &mut ctx)?;
@@ -237,7 +235,7 @@ impl CoseVerifier for OpensslSigner {
         let verif_key = PKey::from_ec_key(ec_key)?;
 
         let mut verifier = Verifier::new(message_digest, &verif_key)?;
-        verifier.update(&data)?;
+        verifier.update(data)?;
 
         let ecdsa_sig = EcdsaSig::from_private_components(
             BigNum::from_slice(&sig[..size])?,

--- a/src/test.rs
+++ b/src/test.rs
@@ -9,7 +9,7 @@ pub(crate) struct SerdeTestCase<T> {
     pub(crate) expected_cbor: Vec<u8>,
 }
 
-impl<'de, T> SerdeTestCase<T>
+impl<T> SerdeTestCase<T>
 where
     T: Debug + Serialize + DeserializeOwned + Eq,
 {

--- a/src/triples.rs
+++ b/src/triples.rs
@@ -6024,11 +6024,10 @@ mod test {
                 alg: HashAlgorithm::Sha256,
                 val: Bytes::from(vec![0x01, 0x02, 0x03]),
             }]),
-            flags: {
-                let mut fm = FlagsMap::default();
-                fm.is_configured = Some(true);
-                Some(fm)
-            },
+            flags: Some(FlagsMap {
+                is_configured: Some(true),
+                ..Default::default()
+            }),
             raw: Some(RawValueType {
                 raw_value: RawValueTypeChoice::TaggedBytes(TaggedBytes::from(Bytes::from(
                     vec![0x04,0x05,0x06],


### PR DESCRIPTION
## Summary

Fixes all **17** pre-existing Clippy failures reported in [#54](https://github.com/veraison/corim-rs/issues/54) (13 on the default CI command, +4 under `feature = "openssl"`). No behaviour changes — lint cleanup only, in a dedicated PR separate from feature work (e.g. x5chain).

Closes #54

## Motivation / problem

`cargo clippy` with the same flags as [`.github/workflows/clippy.yml`](https://github.com/veraison/corim-rs/blob/master/.github/workflows/clippy.yml) failed on `master` with 13 errors; with `--features openssl`, 4 more in `openssl.rs`. This blocked local/CI hygiene for contributors working on the `openssl` feature.

## Changes

| Area | Lint / fix |
|------|------------|
| `comid.rs`, `core.rs`, `corim.rs`, `coswid.rs`, `cotl.rs` | Remove unused `generate_tagged` imports (`#[macro_use]` on `macros` already exports the macro) |
| `coswid.rs` | Drop redundant `0 +` (`identity_op`); add `is_empty()` on `ResourceCollection`, `PathElementsGroup`, `FileSystemItem` (`len_without_is_empty`) |
| `openssl.rs` | Refactor `sign` / `verify_signature` to avoid `needless_late_init`; use `as_ref().is_some_and(\|y\| !y.is_empty())`; `verifier.update(data)?` (`needless_borrow`) |
| `core.rs` | Test: remove useless `.into()` on `ExtensionValue::Array` vec |
| `triples.rs` | Test: `FlagsMap { is_configured: Some(true), ..Default::default() }` (`field_reassign_with_default`) |
| `numbers.rs` | Test: remove `use std::u32` (`legacy_numeric_constants`; `u32::MAX` works without the import) |
| `test.rs` | Remove unused lifetime on `SerdeTestCase` impl (`extra_unused_lifetimes`) |

### Policy choices (from #54)

- **One cleanup PR** for all 17 lints (not split per future feature PR).
- **`is_empty()`** on the three public `coswid` types rather than `#[allow(clippy::len_without_is_empty)]`.
- **CI unchanged** — still `cargo clippy --all-targets` without `--all-features`; this PR also passes with `--features openssl` locally.

## Compatibility

- **Breaking changes:** none.
- **Public API:** adds `is_empty()` on three `coswid` types (additive; consistent with existing `len()`).

## Out of scope

- Enabling `--all-features` in CI (left for maintainer decision in #54).
- Functional changes to PKIX, COSE, or serialization.
- x5chain / trust-verification work (separate branch/PR).

## Test plan

- [x] `cargo clippy --all-targets -- -D clippy::all -D unused_imports -D warnings -D clippy::style` (matches CI)
- [x] `cargo clippy --all-targets --features openssl -- -D clippy::all -D unused_imports -D warnings -D clippy::style`
- [x] `cargo test --all-targets` (default features)
- [x] `cargo test --all-targets --features openssl`